### PR TITLE
Supports non-Canvas rendering.

### DIFF
--- a/baseAtlas.lua
+++ b/baseAtlas.lua
@@ -122,7 +122,11 @@ end
 baseAtlas.getViewport = function(self, id)
   local quad = self.quads[id]
   if quad then
-    return quad:getViewport()
+    if self._pureImageMode then
+      return quad[1], quad[2], quad[3], quad[4]
+    else
+      return quad:getViewport()
+    end
   end
   error("Warning! Quad hasn't been baked for id: " .. tostring(id))
 end

--- a/baseAtlas.lua
+++ b/baseAtlas.lua
@@ -40,7 +40,7 @@ baseAtlas._ensureCorrectImage = function(self, image)
   else
     if image:typeOf("ImageData") then
       if lg then
-        return love.graphics.newImage(image)
+        return lg.newImage(image)
       else
         error("Cannot convert ImageData to Image")
       end

--- a/baseAtlas.lua
+++ b/baseAtlas.lua
@@ -1,5 +1,7 @@
 -- Copyright (c) 2021 EngineerSmith
 -- Under the MIT license, see license suppiled with this file
+local path = select(1, ...):match("(.-)[^%.]+$")
+local util = require(path .. "util")
 
 local lg = love.graphics
 
@@ -28,14 +30,6 @@ baseAtlas.new = function(padding, extrude, spacing)
     _dirty = false, -- Marked dirty if image is added or removed,
     _hardBake = false, -- Marked true if hardBake has been called, cannot use add, remove or bake once true
   }, baseAtlas)
-end
-
-baseAtlas._getImageDimensions = function(image)
-  if image:typeOf("Texture") then
-    return image:getPixelDimensions()
-  else
-    return image:getDimensions()
-  end
 end
 
 baseAtlas._ensureCorrectImage = function(self, image)

--- a/dynamicSize.lua
+++ b/dynamicSize.lua
@@ -1,6 +1,7 @@
 -- Copyright (c) 2021 EngineerSmith
 -- Under the MIT license, see license suppiled with this file
 local path = select(1, ...):match("(.-)[^%.]+$")
+local util = require(path .. "util")
 local baseAtlas = require(path .. "baseAtlas")
 local dynamicSizeTA = setmetatable({}, baseAtlas)
 dynamicSizeTA.__index = dynamicSizeTA
@@ -9,6 +10,7 @@ dynamicSizeTA.__index = dynamicSizeTA
 local treeNode = require(path .. "treeNode")
 
 local lg = love.graphics
+local newImageData = love.image.newImageData
 local sort = table.sort
 
 dynamicSizeTA.new = function(padding, extrude, spacing)
@@ -16,20 +18,20 @@ dynamicSizeTA.new = function(padding, extrude, spacing)
 end
 
 local area = function(a, b)
-  local aW, aH = a.image:getPixelDimensions()
-  local bW, bH = b.image:getPixelDimensions()
+  local aW, aH = util.getImageDimensions(a.image)
+  local bW, bH = util.getImageDimensions(b.image)
   return aW * aH > bW * bH
 end
 
 local height = function(a, b)
-  local aH = a.image:getPixelHeight()
-  local bH = b.image:getPixelHeight()
+  local aH = select(2, util.getImageDimensions(a.image))
+  local bH = select(2, util.getImageDimensions(b.image))
   return aH > bH
 end
 
 local width = function(a, b)
-  local aW = a.image:getPixelWidth()
-  local bW = b.image:getPixelWidth()
+  local aW = util.getImageDimensions(a.image)
+  local bW = util.getImageDimensions(b.image)
   return aW > bW
 end
 
@@ -37,6 +39,7 @@ end
 dynamicSizeTA.bake = function(self, sortBy)
   if self._dirty and not self._hardBake then
     local shallowCopy = {unpack(self.images)}
+    local data
     if sortBy == nil or sortBy == "height" then
       sort(shallowCopy, height)
     elseif sortBy == "area" then
@@ -44,14 +47,14 @@ dynamicSizeTA.bake = function(self, sortBy)
     elseif sortBy == "width" then
       sort(shallowCopy, width)
     end
-    
+
     -- Calculate positions and size of canvas
     local maxWidth, maxHeight = 0,0
     local root = treeNode.new(self._maxCanvasSize, self._maxCanvasSize)
-    
+
     for _, image in ipairs(shallowCopy) do
       local img = image.image
-      local width, height = img:getPixelDimensions()
+      local width, height = util.getImageDimensions(img)
       width = width + self.spacing + self.extrude * 2 + self.padding * 2
       height = height + self.spacing + self.extrude * 2 + self.padding * 2
       local node = root:insert(image, width, height)
@@ -65,27 +68,34 @@ dynamicSizeTA.bake = function(self, sortBy)
         maxHeight = node.y + height
       end
     end
-    
+
     maxWidth, maxHeight = maxWidth - self.spacing, maxHeight - self.spacing
-    
+
     if self.bakeAsPow2 then
       maxWidth = math.pow(2, math.ceil(math.log(maxWidth)/math.log(2)))
       maxHeight = math.pow(2, math.ceil(math.log(maxHeight)/math.log(2)))
     end
-    
-    local canvas = lg.newCanvas(maxWidth, maxHeight, self._canvasSettings)
-    lg.push("all")
-    lg.setBlendMode("replace")
-    lg.setCanvas(canvas)
-    root:draw(self.quads, maxWidth, maxHeight, self.extrude, self.padding)
-    lg.pop()
-    local data = canvas:newImageData()
-    self.image = lg.newImage(data)
-    self.image:setFilter(self.filterMin, self.filterMag)
+
+    if self._pureImageMode then
+      data = newImageData(maxWidth, maxHeight, "rgba8")
+      root:draw(self.quads, maxWidth, maxHeight, self.extrude, self.padding, data)
+      self.image = data
+    else
+      local canvas = lg.newCanvas(maxWidth, maxHeight, self._canvasSettings)
+      lg.push("all")
+      lg.setBlendMode("replace")
+      lg.setCanvas(canvas)
+      root:draw(self.quads, maxWidth, maxHeight, self.extrude, self.padding)
+      lg.pop()
+      data = canvas:newImageData()
+      self.image = lg.newImage(data)
+      self.image:setFilter(self.filterMin, self.filterMag)
+    end
+
     self._dirty = false
     return self, data
   end
-  
+
   return self
 end
 

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -32,6 +32,7 @@ fixedSizeTA.bake = function(self)
     local widthPadded = width + self.spacing + self.extrude * 2 + self.padding * 2
     local heightPadded = height + self.spacing + self.extrude * 2 + self.padding * 2
     local maxIndex = self.imagesSize
+    local data
 
     local widthCanvas = columns * widthPadded
     if widthCanvas > self._maxCanvasSize then
@@ -53,7 +54,7 @@ fixedSizeTA.bake = function(self)
     end
 
     if self._pureImageMode then
-      local imageData = love.image.newImageData(widthCanvas, heightCanvas, "rgba8")
+      data = love.image.newImageData(widthCanvas, heightCanvas, "rgba8")
       for x=0, columns-1 do
         for y=0, rows-1 do
           local index = (x+y*rows)+1
@@ -62,9 +63,9 @@ fixedSizeTA.bake = function(self)
           end
           local x, y = x * widthPadded + self.padding + self.extrude, y * heightPadded + self.padding + self.extrude
           local image = self.images[index]
-          imageData:paste(image, x, y, 0, 0, image:getDimensions())
+          data:paste(image, x, y, 0, 0, image:getDimensions())
           if self.extrude > 0 then
-            util.extrudeWithFill(imageData, image, self.extrude, x, y)
+            util.extrudeWithFill(data, image, self.extrude, x, y)
           end
           self.quads[image.id] = {x+self.extrude, y+self.extrude, width, height}
         end
@@ -92,13 +93,13 @@ fixedSizeTA.bake = function(self)
         end
       end
       lg.pop()
-      local data = canvas:newImageData()
+      data = canvas:newImageData()
       self.image = lg.newImage(data)
       self.image:setFilter(self.filterMin, self.filterMag)
       self._dirty = false
     end
 
-    return self, self.image
+    return self, data
   end
 
   return self

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -3,24 +3,12 @@
 
 local path = select(1, ...):match("(.-)[^%.]+$")
 local baseAtlas = require(path .. "baseAtlas")
+local util = require(path .. "util")
 local fixedSizeTA = setmetatable({}, baseAtlas)
 fixedSizeTA.__index = fixedSizeTA
 
 local lg = love.graphics
 local ceil, floor, sqrt = math.ceil, math.sqrt, math.floor
-
--- TODO: Remove closure usage
-local fillImageData = function(imageData, x, y, w, h, r, g, b, a)
-  imageData:mapPixel(function()
-    return r, g, b, a
-  end, x, y, w, h)
-end
-
-local extrudeImageData = function(dest, src, n, x, y, dx, dy, sx, sy, sw, sh)
-  for i = 1, n do
-    dest:paste(src, x + i * dx, y + i * dy, sx, sy, sw, sh)
-  end
-end
 
 fixedSizeTA.new = function(width, height, padding, extrude, spacing)
   local self = setmetatable(baseAtlas.new(padding, extrude, spacing), fixedSizeTA)
@@ -30,7 +18,7 @@ fixedSizeTA.new = function(width, height, padding, extrude, spacing)
 end
 
 fixedSizeTA.add = function(self, image, id, bake)
-  local width, height = baseAtlas._getImageDimensions(image)
+  local width, height = util.getImageDimensions(image)
   if width ~= self.width or height ~= self.height then
     error("Given image cannot fit into a fixed sized texture atlas\n Gave: W:".. tostring(width) .. " H:" ..tostring(height) .. ", Expected: W:"..self.width.." H:"..self.height)
   end
@@ -77,14 +65,14 @@ fixedSizeTA.bake = function(self)
           local iw, ih = image:getDimensions()
           imageData:paste(image, x, y, 0, 0, iw, ih)
           if self.extrude > 0 then
-            extrudeImageData(imageData, image, self.extrude, x, y, 0, -1, 0, 0, iw, 1) -- top
-            extrudeImageData(imageData, image, self.extrude, x, y, -1, 0, 0, 0, 1, ih) -- left
-            extrudeImageData(imageData, image, self.extrude, x, y + ih - 1, 0, 1, 0, ih - 1, iw, 1) -- bottom
-            extrudeImageData(imageData, image, self.extrude, x + iw - 1, y, 1, 0, iw - 1, 0, 1, ih) -- right
-            fillImageData(imageData, x - self.extrude - 1, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(0, 0)) -- top-left
-            fillImageData(imageData, x + iw, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(iw - 1, 0)) -- top-right
-            fillImageData(imageData, x + iw, y + ih, self.extrude, self.extrude, image:getPixel(iw - 1, ih - 1)) -- bottom-right
-            fillImageData(imageData, x - self.extrude - 1, y + ih, self.extrude, self.extrude, image:getPixel(0, ih - 1)) -- bottom-left
+            util.extrudeImageData(imageData, image, self.extrude, x, y, 0, -1, 0, 0, iw, 1) -- top
+            util.extrudeImageData(imageData, image, self.extrude, x, y, -1, 0, 0, 0, 1, ih) -- left
+            util.extrudeImageData(imageData, image, self.extrude, x, y + ih - 1, 0, 1, 0, ih - 1, iw, 1) -- bottom
+            util.extrudeImageData(imageData, image, self.extrude, x + iw - 1, y, 1, 0, iw - 1, 0, 1, ih) -- right
+            util.fillImageData(imageData, x - self.extrude - 1, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(0, 0)) -- top-left
+            util.fillImageData(imageData, x + iw, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(iw - 1, 0)) -- top-right
+            util.fillImageData(imageData, x + iw, y + ih, self.extrude, self.extrude, image:getPixel(iw - 1, ih - 1)) -- bottom-right
+            util.fillImageData(imageData, x - self.extrude - 1, y + ih, self.extrude, self.extrude, image:getPixel(0, ih - 1)) -- bottom-left
           end
         end
       end

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -64,9 +64,9 @@ fixedSizeTA.bake = function(self)
           end
           local x, y = x * widthPadded + self.padding + self.extrude, y * heightPadded + self.padding + self.extrude
           local image = self.images[index]
-          data:paste(image, x, y, 0, 0, image:getDimensions())
+          data:paste(image.image, x, y, 0, 0, image.image:getDimensions())
           if self.extrude > 0 then
-            util.extrudeWithFill(data, image, self.extrude, x, y)
+            util.extrudeWithFill(data, image.image, self.extrude, x, y)
           end
           self.quads[image.id] = {x+self.extrude, y+self.extrude, width, height}
         end

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -97,9 +97,9 @@ fixedSizeTA.bake = function(self)
       data = canvas:newImageData()
       self.image = lg.newImage(data)
       self.image:setFilter(self.filterMin, self.filterMag)
-      self._dirty = false
     end
 
+    self._dirty = false
     return self, data
   end
 

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -9,6 +9,19 @@ fixedSizeTA.__index = fixedSizeTA
 local lg = love.graphics
 local ceil, floor, sqrt = math.ceil, math.sqrt, math.floor
 
+-- TODO: Remove closure usage
+local fillImageData = function(imageData, x, y, w, h, r, g, b, a)
+  imageData:mapPixel(function()
+    return r, g, b, a
+  end, x, y, w, h)
+end
+
+local extrudeImageData = function(dest, src, n, x, y, dx, dy, sx, sy, sw, sh)
+  for i = 1, n do
+    dest:paste(src, x + i * dx, y + i * dy, sx, sy, sw, sh)
+  end
+end
+
 fixedSizeTA.new = function(width, height, padding, extrude, spacing)
   local self = setmetatable(baseAtlas.new(padding, extrude, spacing), fixedSizeTA)
   self.width = width or error("Width required")
@@ -17,7 +30,7 @@ fixedSizeTA.new = function(width, height, padding, extrude, spacing)
 end
 
 fixedSizeTA.add = function(self, image, id, bake)
-  local width, height = image:getDimensions()
+  local width, height = baseAtlas._getImageDimensions(image)
   if width ~= self.width or height ~= self.height then
     error("Given image cannot fit into a fixed sized texture atlas\n Gave: W:".. tostring(width) .. " H:" ..tostring(height) .. ", Expected: W:"..self.width.." H:"..self.height)
   end
@@ -30,55 +43,83 @@ fixedSizeTA.bake = function(self)
     local width, height = self.width, self.height
     local widthPadded = width + self.spacing + self.extrude * 2 + self.padding * 2
     local heightPadded = height + self.spacing + self.extrude * 2 + self.padding * 2
-    
+    local maxIndex = self.imagesSize
+
     local widthCanvas = columns * widthPadded
     if widthCanvas > self._maxCanvasSize then
       columns = floor(self._maxCanvasSize / width)
       widthCanvas = columns * widthPadded
     end
-    
+
     local rows = ceil(self.imagesSize / columns)
     local heightCanvas = rows * heightPadded
     if heightPadded > self._maxCanvasSize then
       rows = floor(self._maxCanvasSize / height)
       heightCanvas = rows * heightPadded
     end
-    
-    if columns * rows < self.imagesSize then
-      error("Cannot support "..tostring(self.imagesSize).." images, due to system limits of canvas size. Max allowed on this system: "..tostring(columns * rows))
-    end
-    
-    local extrudeQuad = lg.newQuad(-self.extrude, -self.extrude, width+self.extrude*2, height+self.extrude*2, self.width, self.height)
+
     widthCanvas, heightCanvas = widthCanvas - self.spacing, heightCanvas - self.spacing
     if self.bakeAsPow2 then
       widthCanvas = math.pow(2, math.ceil(math.log(widthCanvas)/math.log(2)))
       heightCanvas = math.pow(2, math.ceil(math.log(heightCanvas)/math.log(2)))
     end
-    local canvas = lg.newCanvas(widthCanvas, heightCanvas, self._canvasSettings)
-    local maxIndex = self.imagesSize
-    lg.push("all")
-    lg.setBlendMode("replace")
-    lg.setCanvas(canvas)
-    for x=0, columns-1 do
-      for y=0, rows-1 do
-        local index = (x+y*rows)+1
-        if index > maxIndex then
-          break
+
+    if self._pureImageMode then
+      local imageData = love.image.newImageData(widthCanvas, heightCanvas, "rgba8")
+      for x=0, columns-1 do
+        for y=0, rows-1 do
+          local index = (x+y*rows)+1
+          if index > maxIndex then
+            break
+          end
+          local x, y = x * widthPadded + self.padding, y * heightPadded + self.padding
+          local image = self.images[index]
+          local iw, ih = image:getDimensions()
+          imageData:paste(image, x, y, 0, 0, iw, ih)
+          if self.extrude > 0 then
+            extrudeImageData(imageData, image, self.extrude, x, y, 0, -1, 0, 0, iw, 1) -- top
+            extrudeImageData(imageData, image, self.extrude, x, y, -1, 0, 0, 0, 1, ih) -- left
+            extrudeImageData(imageData, image, self.extrude, x, y + ih - 1, 0, 1, 0, ih - 1, iw, 1) -- bottom
+            extrudeImageData(imageData, image, self.extrude, x + iw - 1, y, 1, 0, iw - 1, 0, 1, ih) -- right
+            fillImageData(imageData, x - self.extrude - 1, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(0, 0)) -- top-left
+            fillImageData(imageData, x + iw, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(iw - 1, 0)) -- top-right
+            fillImageData(imageData, x + iw, y + ih, self.extrude, self.extrude, image:getPixel(iw - 1, ih - 1)) -- bottom-right
+            fillImageData(imageData, x - self.extrude - 1, y + ih, self.extrude, self.extrude, image:getPixel(0, ih - 1)) -- bottom-left
+          end
         end
-        local x, y = x * widthPadded + self.padding, y * heightPadded + self.padding
-        local image = self.images[index]
-        lg.draw(image.image, extrudeQuad, x, y)
-        self.quads[image.id] = lg.newQuad(x+self.extrude, y+self.extrude, width, height, widthCanvas, heightCanvas)
       end
+    else
+      if columns * rows < self.imagesSize then
+        error("Cannot support "..tostring(self.imagesSize).." images, due to system limits of canvas size. Max allowed on this system: "..tostring(columns * rows))
+      end
+
+      local extrudeQuad = lg.newQuad(-self.extrude, -self.extrude, width+self.extrude*2, height+self.extrude*2, self.width, self.height)
+      local canvas = lg.newCanvas(widthCanvas, heightCanvas, self._canvasSettings)
+      lg.push("all")
+      lg.setBlendMode("replace")
+      lg.setCanvas(canvas)
+      for x=0, columns-1 do
+        for y=0, rows-1 do
+          local index = (x+y*rows)+1
+          if index > maxIndex then
+            break
+          end
+          local x, y = x * widthPadded + self.padding, y * heightPadded + self.padding
+          local image = self.images[index]
+          lg.draw(image.image, extrudeQuad, x, y)
+          self.quads[image.id] = lg.newQuad(x+self.extrude, y+self.extrude, width, height, widthCanvas, heightCanvas)
+        end
+      end
+      lg.pop()
+      local data = canvas:newImageData()
+      self.image = lg.newImage(data)
+      self.image:setFilter(self.filterMin, self.filterMag)
+      self._dirty = false
     end
-    lg.pop()
-    local data = canvas:newImageData()
-    self.image = lg.newImage(data)
-    self.image:setFilter(self.filterMin, self.filterMag)
-    self._dirty = false
-    return self, data
+
+    return self, self.image
   end
-  
+
   return self
 end
 

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -8,6 +8,7 @@ local fixedSizeTA = setmetatable({}, baseAtlas)
 fixedSizeTA.__index = fixedSizeTA
 
 local lg = love.graphics
+local newImageData = love.image.newImageData
 local ceil, floor, sqrt = math.ceil, math.sqrt, math.floor
 
 fixedSizeTA.new = function(width, height, padding, extrude, spacing)
@@ -54,7 +55,7 @@ fixedSizeTA.bake = function(self)
     end
 
     if self._pureImageMode then
-      data = love.image.newImageData(widthCanvas, heightCanvas, "rgba8")
+      data = newImageData(widthCanvas, heightCanvas, "rgba8")
       for x=0, columns-1 do
         for y=0, rows-1 do
           local index = (x+y*rows)+1

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -60,7 +60,7 @@ fixedSizeTA.bake = function(self)
           if index > maxIndex then
             break
           end
-          local x, y = x * widthPadded + self.padding, y * heightPadded + self.padding
+          local x, y = x * widthPadded + self.padding + self.extrude, y * heightPadded + self.padding + self.extrude
           local image = self.images[index]
           imageData:paste(image, x, y, 0, 0, image:getDimensions())
           if self.extrude > 0 then

--- a/fixedSize.lua
+++ b/fixedSize.lua
@@ -62,18 +62,11 @@ fixedSizeTA.bake = function(self)
           end
           local x, y = x * widthPadded + self.padding, y * heightPadded + self.padding
           local image = self.images[index]
-          local iw, ih = image:getDimensions()
-          imageData:paste(image, x, y, 0, 0, iw, ih)
+          imageData:paste(image, x, y, 0, 0, image:getDimensions())
           if self.extrude > 0 then
-            util.extrudeImageData(imageData, image, self.extrude, x, y, 0, -1, 0, 0, iw, 1) -- top
-            util.extrudeImageData(imageData, image, self.extrude, x, y, -1, 0, 0, 0, 1, ih) -- left
-            util.extrudeImageData(imageData, image, self.extrude, x, y + ih - 1, 0, 1, 0, ih - 1, iw, 1) -- bottom
-            util.extrudeImageData(imageData, image, self.extrude, x + iw - 1, y, 1, 0, iw - 1, 0, 1, ih) -- right
-            util.fillImageData(imageData, x - self.extrude - 1, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(0, 0)) -- top-left
-            util.fillImageData(imageData, x + iw, y - self.extrude - 1, self.extrude, self.extrude, image:getPixel(iw - 1, 0)) -- top-right
-            util.fillImageData(imageData, x + iw, y + ih, self.extrude, self.extrude, image:getPixel(iw - 1, ih - 1)) -- bottom-right
-            util.fillImageData(imageData, x - self.extrude - 1, y + ih, self.extrude, self.extrude, image:getPixel(0, ih - 1)) -- bottom-left
+            util.extrudeWithFill(imageData, image, self.extrude, x, y)
           end
+          self.quads[image.id] = {x+self.extrude, y+self.extrude, width, height}
         end
       end
     else

--- a/treeNode.lua
+++ b/treeNode.lua
@@ -10,14 +10,13 @@ treeNode.__index = treeNode
 
 local lg = love.graphics
 
-treeNode.new = function(w, h, imageData)
+treeNode.new = function(w, h)
   return setmetatable({
     x = 0,
     y = 0,
     w = w or 0,
     h = h or 0,
     image = nil,
-    imageData = imageData
   }, treeNode)
 end
 
@@ -67,15 +66,15 @@ treeNode.insert = function(self, image, width, height)
   end
 end
 
-treeNode.draw = function(self, quads, width, height, extrude, padding)
+treeNode.draw = function(self, quads, width, height, extrude, padding, imageData)
   if self.image then
     local img = self.image.image
     local iwidth, iheight = util.getImageDimensions(img)
-    if self.imageData then
+    if imageData then
       local x, y = self.x + padding + extrude, self.y + padding + extrude
-      self.imageData:paste(img, x, y, 0, 0, img:getDimensions())
+      imageData:paste(img, x, y, 0, 0, img:getDimensions())
       if extrude > 0 then
-        util.extrudeWithFill(self.imageData, img, extrude, x, y)
+        util.extrudeWithFill(imageData, img, extrude, x, y)
       end
       quads[self.image.id] = {x, y, iwidth, iheight}
     else
@@ -84,8 +83,8 @@ treeNode.draw = function(self, quads, width, height, extrude, padding)
       quads[self.image.id] = lg.newQuad(self.x+extrude+padding, self.y+extrude+padding, iwidth, iheight, width, height)
     end
   elseif self[1] --[[ and self[2] ]] then
-    self[1]:draw(quads, width, height, extrude, padding)
-    self[2]:draw(quads, width, height, extrude, padding)
+    self[1]:draw(quads, width, height, extrude, padding, imageData)
+    self[2]:draw(quads, width, height, extrude, padding, imageData)
   end
 end
 

--- a/treeNode.lua
+++ b/treeNode.lua
@@ -1,19 +1,23 @@
 -- Copyright (c) 2021 EngineerSmith
 -- Under the MIT license, see license suppiled with this file
 
+local path = select(1, ...):match("(.-)[^%.]+$")
+local util = require(path .. "util")
+
 -- Based on BlackPawn's lightmap packing algorithm: https://blackpawn.com/texts/lightmaps/default.html
 local treeNode = {}
 treeNode.__index = treeNode
 
 local lg = love.graphics
 
-treeNode.new = function(w, h)
+treeNode.new = function(w, h, imageData)
   return setmetatable({
     x = 0,
     y = 0,
     w = w or 0,
     h = h or 0,
     image = nil,
+    imageData = imageData
   }, treeNode)
 end
 
@@ -31,11 +35,11 @@ treeNode.insert = function(self, image, width, height)
       self.image = image
       return self
     end
-    
+
     self[1] = self.new()
     self[2] = self.new()
-    
-    if (self.w - width) > (self.h - height) then -- Vertical 
+
+    if (self.w - width) > (self.h - height) then -- Vertical
        -- Left
       self[1].x = self.x
       self[1].y = self.y
@@ -58,7 +62,7 @@ treeNode.insert = function(self, image, width, height)
       self[2].w = self.w
       self[2].h = self.h - height
     end
-    
+
     return self[1]:insert(image, width, height)
   end
 end
@@ -66,11 +70,20 @@ end
 treeNode.draw = function(self, quads, width, height, extrude, padding)
   if self.image then
     local img = self.image.image
-    local iwidth, iheight = img:getDimensions()
-    local extrudeQuad = lg.newQuad(-extrude, -extrude, iwidth+extrude*2, iheight+extrude*2, iwidth, iheight)
-    lg.draw(img, extrudeQuad, self.x + padding, self.y + padding)
-    quads[self.image.id] = lg.newQuad(self.x+extrude+padding, self.y+extrude+padding, iwidth, iheight, width, height)
-  elseif self[1] --[[ and self[2] ]] then 
+    local iwidth, iheight = util.getImageDimensions(img)
+    if self.imageData then
+      local x, y = self.x + padding + extrude, self.y + padding + extrude
+      self.imageData:paste(img, x, y, 0, 0, img:getDimensions())
+      if extrude > 0 then
+        util.extrudeWithFill(self.imageData, img, extrude, x, y)
+      end
+      quads[self.image.id] = {x, y, iwidth, iheight}
+    else
+      local extrudeQuad = lg.newQuad(-extrude, -extrude, iwidth+extrude*2, iheight+extrude*2, iwidth, iheight)
+      lg.draw(img, extrudeQuad, self.x + padding, self.y + padding)
+      quads[self.image.id] = lg.newQuad(self.x+extrude+padding, self.y+extrude+padding, iwidth, iheight, width, height)
+    end
+  elseif self[1] --[[ and self[2] ]] then
     self[1]:draw(quads, width, height, extrude, padding)
     self[2]:draw(quads, width, height, extrude, padding)
   end

--- a/util.lua
+++ b/util.lua
@@ -31,10 +31,10 @@ util.extrudeWithFill = function(dest, src, n, x, y)
   extrudeImageData(dest, src, n, x, y, -1, 0, 0, 0, 1, ih) -- left
   extrudeImageData(dest, src, n, x, y + ih - 1, 0, 1, 0, ih - 1, iw, 1) -- bottom
   extrudeImageData(dest, src, n, x + iw - 1, y, 1, 0, iw - 1, 0, 1, ih) -- right
-  fillImageData(dest, x - n - 1, y - n - 1, n, n, src:getPixel(0, 0)) -- top-left
-  fillImageData(dest, x + iw, y - n - 1, n, n, src:getPixel(iw - 1, 0)) -- top-right
+  fillImageData(dest, x - n, y - n, n, n, src:getPixel(0, 0)) -- top-left
+  fillImageData(dest, x + iw, y - n, n, n, src:getPixel(iw - 1, 0)) -- top-right
   fillImageData(dest, x + iw, y + ih, n, n, src:getPixel(iw - 1, ih - 1)) -- bottom-right
-  fillImageData(dest, x - n - 1, y + ih, n, n, src:getPixel(0, ih - 1)) -- bottom-left
+  fillImageData(dest, x - n, y + ih, n, n, src:getPixel(0, ih - 1)) -- bottom-left
 end
 
 return util

--- a/util.lua
+++ b/util.lua
@@ -1,0 +1,40 @@
+-- Copyright (c) 2021 EngineerSmith
+-- Under the MIT license, see license suppiled with this file
+
+local util = {}
+
+util.getImageDimensions = function(image)
+  if image:typeOf("Texture") then
+    return image:getPixelDimensions()
+  else
+    return image:getDimensions()
+  end
+end
+
+
+-- TODO: Remove closure usage
+local fillImageData = function(imageData, x, y, w, h, r, g, b, a)
+  imageData:mapPixel(function()
+    return r, g, b, a
+  end, x, y, w, h)
+end
+
+local extrudeImageData = function(dest, src, n, x, y, dx, dy, sx, sy, sw, sh)
+  for i = 1, n do
+    dest:paste(src, x + i * dx, y + i * dy, sx, sy, sw, sh)
+  end
+end
+
+util.extrudeWithFill = function(dest, src, n, x, y)
+  local iw, ih = src:getDimensions()
+  extrudeImageData(dest, src, n, x, y, 0, -1, 0, 0, iw, 1) -- top
+  extrudeImageData(dest, src, n, x, y, -1, 0, 0, 0, 1, ih) -- left
+  extrudeImageData(dest, src, n, x, y + ih - 1, 0, 1, 0, ih - 1, iw, 1) -- bottom
+  extrudeImageData(dest, src, n, x + iw - 1, y, 1, 0, iw - 1, 0, 1, ih) -- right
+  fillImageData(dest, x - n - 1, y - n - 1, n, n, src:getPixel(0, 0)) -- top-left
+  fillImageData(dest, x + iw, y - n - 1, n, n, src:getPixel(iw - 1, 0)) -- top-right
+  fillImageData(dest, x + iw, y + ih, n, n, src:getPixel(iw - 1, ih - 1)) -- bottom-right
+  fillImageData(dest, x - n - 1, y + ih, n, n, src:getPixel(0, ih - 1)) -- bottom-left
+end
+
+return util


### PR DESCRIPTION
Added `baseAtlas:useImageData(boolean)` to tell if this atlas should use ImageData rendering or not. ImageData rendering is default if `love.graphics` is not loaded. That function can only be called if the atlas contents are empty; you can't switch between ImageData and Canvas rendering if there's at least one texture in the atlas.

~~I haven't tested this (will edit when I did).~~ Please let me know it's ready to merge or if there some changes I need to apply.